### PR TITLE
Adding German Language Package

### DIFF
--- a/sample/warp/menu.json
+++ b/sample/warp/menu.json
@@ -1,6 +1,6 @@
 [
    {
-      "Title":"Administration",
+      "Title":"Administration Apps",
       "Entries":[
          {
             "DisplayName":"UniverseADM",
@@ -60,7 +60,7 @@
       ]
    },
    {
-      "Title":"Development",
+      "Title":"Development Apps",
       "Entries":[
          {
             "DisplayName":"SCM-Manager",

--- a/src/warp.js
+++ b/src/warp.js
@@ -2,6 +2,9 @@ var baseUrl = '';
 
 var head = document.getElementsByTagName('head')[0];
 var body = document.getElementsByTagName('body')[0];
+var languageKeyValueMap = new Map([["Development Apps", "Entwicklung"], ["Documentation", "Dokumentation"], ["Administration Apps", "Administration"]]);
+
+
 
 var lss = isLocalStorageSupported();
 
@@ -26,7 +29,25 @@ function isLocalStorageSupported(){
   }
 }
 
+function getLanguage() {
+    var language = navigator.languages
+        ? navigator.languages[0]
+        : (navigator.language || navigator.userLanguage);
+
+    return language;
+}
+
+
 function getCategoryKey(category){
+  var language = getLanguage();
+
+  //if language = German, change category.title to German language
+    if(language.indexOf("de") > -1){
+      if(languageKeyValueMap.has(category.Title)){
+        category.Title = languageKeyValueMap.get(category.Title);
+      }
+    }
+
   return "warpc." + category.Title.toLowerCase().replace(/\s+/g, "_");
 }
 
@@ -52,6 +73,7 @@ function toggleCategory(e){
 }
 
 function initWarpMenu(categories){
+    getLanguage();
   addClass(body, 'warpmenu-push');
 
   // create html
@@ -118,7 +140,7 @@ function initWarpMenu(categories){
 
   // fixed about page - entry
   var ul = document.createElement('ul');
-  var id = "warpc.test";
+  var id = "warpc.info";
   ul.id = id;
   var collapsed = false;
   if (lss){

--- a/src/warp.js
+++ b/src/warp.js
@@ -73,7 +73,6 @@ function toggleCategory(e){
 }
 
 function initWarpMenu(categories){
-    getLanguage();
   addClass(body, 'warpmenu-push');
 
   // create html

--- a/src/warp.js
+++ b/src/warp.js
@@ -2,8 +2,8 @@ var baseUrl = '';
 
 var head = document.getElementsByTagName('head')[0];
 var body = document.getElementsByTagName('body')[0];
-var languageKeyValueMap = new Map([["Development Apps", "Entwicklung"], ["Documentation", "Dokumentation"], ["Administration Apps", "Administration"]]);
-
+var germanObject = {"Development Apps":"Entwicklung", "Administration Apps": "Administration", "Documentation": "Dokumentation"};
+var languageArray = {"de": germanObject};
 
 
 var lss = isLocalStorageSupported();
@@ -32,7 +32,7 @@ function isLocalStorageSupported(){
 function getLanguage() {
     var language = navigator.languages
         ? navigator.languages[0]
-        : (navigator.language || navigator.userLanguage);
+        : (navigator.language || navigator.userLanguage || navigator.browserLanguage);
 
     return language;
 }
@@ -43,9 +43,8 @@ function getCategoryKey(category){
 
   //if language = German, change category.title to German language
     if(language.indexOf("de") > -1){
-      if(languageKeyValueMap.has(category.Title)){
-        category.Title = languageKeyValueMap.get(category.Title);
-      }
+        if(languageArray["de"][category.Title]!== undefined)
+            category.Title=languageArray["de"][category.Title];
     }
 
   return "warpc." + category.Title.toLowerCase().replace(/\s+/g, "_");


### PR DESCRIPTION
1. Modified example: changed names of the categories to the one who are actually used in ecosystems to be able to test German/English language
2. Added German language solution: Whenever German language is set in Browser, the Warp Menu will be translated into German (only if there is an value for the key (English name))