### PR TITLE
Catch edge case where Information entries don't map.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- fixes "Information" category mapping if no "Support" category is present (#36)
 
 ## [v1.5.0](https://github.com/cloudogu/warp-menu/releases/tag/v1.5.0)
 ### Added

--- a/src/warp.js
+++ b/src/warp.js
@@ -265,7 +265,7 @@ function createMenu(categories) {
     var homeElement = createHomeWithImage();
     list.appendChild(homeElement);
 
-    var informationEntries = [];
+    let informationEntries = [];
 
     for (var c = 0; c < categories.length; c++) {
         var currentCategory = categories[c];
@@ -278,7 +278,8 @@ function createMenu(categories) {
             continue;
         }
         if (currentCategory.Title.toUpperCase() === "SUPPORT") {
-            informationEntries.map(e => currentCategory.Entries.unshift(e))
+            informationEntries.map(e => currentCategory.Entries.unshift(e)) // prepends information entries to support category
+            informationEntries = [] // set to empty array, so we know the information entries have been mapped to support
         }
         /*---*/
 
@@ -288,6 +289,14 @@ function createMenu(categories) {
         }
         var id = getCategoryKey(currentCategory);
         createMenuEntry(id, currentCategory.Entries, title, list);
+    }
+
+    /**
+     * This catches the edge case when "Information" entries should be mapped to the "Support" category but no "Support"
+     * category is present.
+     */
+    if (informationEntries.length > 0) {
+        createMenuEntry("Support", informationEntries, "Support", list);
     }
 
     addLogoutMenuEntry(list);


### PR DESCRIPTION
This fixes the case when no "Support" category is present but custom entries in the "Information" category should be mapped to "Support".

Update CHANGELOG.md.

the following `menu.json` can be used to test the fix.
```
[
  {
    "Title": "External4",
    "Entries": [
      {
        "DisplayName": "scm-manager.org",
        "Href": "https://scm-manager.org",
        "Title": "Home of SCM-Manager",
        "Target": "external"
      },
      {
        "DisplayName": "scm-manager.org",
        "Href": "https://scm-manager.org",
        "Title": "Home of SCM-Manager",
        "Target": "external"
      }
    ]
  },
  {
    "Title": "External5",
    "Entries": [
      {
        "DisplayName": "scm-manager.org",
        "Href": "https://scm-manager.org",
        "Title": "Home of SCM-Manager",
        "Target": "external"
      },
      {
        "DisplayName": "scm-manager.org",
        "Href": "https://scm-manager.org",
        "Title": "Home of SCM-Manager",
        "Target": "external"
      }
    ]
  },
  {
    "Title": "Information",
    "Order": 0,
    "Entries": [
      {
        "DisplayName": "This comes from the Information category",
        "Href": "/static/privacy_policies.html",
        "Title": "Contains information about the privacy policies enforced by our company",
        "Target": "external"
      }
    ]
  }
]
``