### PR TITLE
Fix: Remove Warp Menu from print layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+Remove Warp Menu from print layouts (#41)
 
 ## [v1.7.0](https://github.com/cloudogu/warp-menu/releases/tag/v1.7.0)
 ### Changed

--- a/src/warp.js
+++ b/src/warp.js
@@ -332,6 +332,7 @@ function setMenuCorrectPosition() {
 function initWarpMenu(categories) {
     var warpMenuContainer = document.createElement('div');
     addClass(warpMenuContainer, 'warp-menu-container');
+    addClass(warpMenuContainer, 'print-hidden');
     addClass(warpMenuContainer, 'notransition');
     warpMenuContainer.id = 'warp-menu-container';
 

--- a/src/warp.scss
+++ b/src/warp.scss
@@ -775,3 +775,10 @@ $font-family-sans-serif-bold: 'Droid Sans Bold', sans-serif;
     }
   }
 }
+
+/*Hide warp menu for print*/
+@media print {
+  .print-hidden {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Add style to hide warp menu when generating print layouts.
 Resolves #41 