### PR TITLE
[#54] Use the same font-stack for warp-menu as in the "CES-Tailwind"-…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Use the same font-stack for warp-menu as in the "CES-Tailwind"-theme (#54)
 
 ## [v2.0.1](https://github.com/cloudogu/warp-menu/releases/tag/v2.0.1)
 ### Changed

--- a/src/generated.css
+++ b/src/generated.css
@@ -57,7 +57,7 @@ html,
   -o-tab-size: 4;
      tab-size: 4;
   /* 3 */
-  font-family: Droid Sans, Calibri, sans-serif;
+  font-family: Calibri, Gill Sans, Gill Sans MT, Liberation Sans, Carlito, -apple-system, BlinkMacSystemFont, avenir next, avenir, segoe ui, helvetica neue, helvetica, Cantarell, Ubuntu, roboto, noto, arial, sans-serif;
   /* 4 */
   font-feature-settings: normal;
   /* 5 */


### PR DESCRIPTION
…theme

- to prenvent overriding of Droid-Sans in different dogus, the font-stak should be the same for all components