### PR TITLE
[#56] Fix screenreader role for menu entries as link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adapt aria rules for better screenreader support in submenus (#56)
 
 ## [v2.0.2](https://github.com/cloudogu/warp-menu/releases/tag/v2.0.2)
 ### Changed

--- a/docs/gui/release_notes_de.md
+++ b/docs/gui/release_notes_de.md
@@ -4,6 +4,9 @@ Im Folgenden finden Sie die Release Notes für das Warp-Menü.
 
 Technische Details zu einem Release finden Sie im zugehörigen [Changelog](https://docs.cloudogu.com/de/docs/system-components/warp-menu/CHANGELOG/).
 
+## Release 2.0.3
+- Es wurden nur technische Änderungen vorgenommen. Nähe Informationen finden Sie im Changelog.
+
 ## Release 2.0.2
 - Es wurden nur technische Änderungen vorgenommen. Nähe Informationen finden Sie im Changelog.
 

--- a/docs/gui/release_notes_en.md
+++ b/docs/gui/release_notes_en.md
@@ -4,6 +4,9 @@ Below you will find the release notes for the Warp Menu.
 
 Technical details on a release can be found in the corresponding [Changelog](https://docs.cloudogu.com/en/docs/system-components/warp-menu/CHANGELOG/).
 
+## Release 2.0.3
+- Only technical changes were made. For more information, see the changelog.
+
 ## Release 2.0.2
 - Only technical changes were made. For more information, see the changelog.
 

--- a/src/generated.css
+++ b/src/generated.css
@@ -1100,6 +1100,10 @@ legend{
   padding-bottom: 16px;
 }
 
+.align-text-top{
+  vertical-align: text-top;
+}
+
 .text-\[1\.125rem\]{
   font-size: 18px;
 }

--- a/src/warp.js
+++ b/src/warp.js
@@ -141,17 +141,15 @@ export function createCategory(category) {
         return `
                     <li>
                         <a
-                        role="menuitem"
                         href="${e.Href}"
                         target="${isExternalLink ? "_blank" : "_top"}" 
                         class="py-default no-underline px-default-2x text-warp-text cursor-pointer focus-visible:ces-focused outline-none
-                           hover:text-warp-text-hover focus-visible:text-warp-text-hover active:text-warp-text-active break-all
+                           hover:text-warp-text-hover focus-visible:text-warp-text-hover active:text-warp-text-active
                            hover:bg-warp-bg-hover focus-visible:bg-warp-bg-hover active:bg-warp-bg-active flex flex-row flex-wrap
                            items-center box-border border-l border-l-transparent border-b border-b-transparent
                            hover:border-l-warp-border active:border-l-warp-border focus-visible:border-l-warp-border
                            hover:border-b-warp-border active:border-b-warp-border focus-visible:border-b-warp-border">
-                           ${linkText.split(" ").reduce((a, b) => `${a}<span>${b}&nbsp;</span>`, "")}
-                            ${(isExternalLink) ? externalIcon : ""}
+                           ${linkText} ${(isExternalLink) ? externalIcon : ""}
                        </a>
                     </li>
                     `;

--- a/src/warp.js
+++ b/src/warp.js
@@ -137,7 +137,8 @@ export function createCategory(category) {
                     ${category.Entries.map(e => {
         const isExternalLink = !!e.Target && e.Target === 'external';
         const linkText = isTranslateable(e.Title) ? getLocalizedString(e.Title) : e.DisplayName;
-        const externalIcon = `<span class="w-[1em] h-[1em] inline-block">${svgExternalLink}</span>`;
+        const externalIcon = `&nbsp;<span class="w-[1em] h-[1em] inline-block align-text-top">${svgExternalLink}</span>`;
+        const textParts = linkText.split(" ")
         return `
                     <li>
                         <a
@@ -149,7 +150,8 @@ export function createCategory(category) {
                            items-center box-border border-l border-l-transparent border-b border-b-transparent
                            hover:border-l-warp-border active:border-l-warp-border focus-visible:border-l-warp-border
                            hover:border-b-warp-border active:border-b-warp-border focus-visible:border-b-warp-border">
-                           ${linkText} ${(isExternalLink) ? externalIcon : ""}
+                           ${textParts.slice(0,-1).reduce((a, b) => `${a}<span>${b}&nbsp;</span>`, "")}
+                           <span>${textParts.slice(-1)}${(isExternalLink) ? externalIcon : ""}</span>
                        </a>
                     </li>
                     `;


### PR DESCRIPTION
* remove menuentry as role, because it overrides the a-link default role
* remove break-all style because Text should not be extended with additional spaces
* write text in one span together with the optional external link icon to reduce number of spaces